### PR TITLE
Removed circular dependencie in uvue loader

### DIFF
--- a/packages/@uvue/vue-cli-plugin-ssr/ApiUtil.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/ApiUtil.js
@@ -1,0 +1,113 @@
+const fs = require('fs-extra');
+const { merge, get } = require('lodash');
+const path = require('path');
+
+
+module.exports = class {
+  constructor(api) {
+    this.api = api;
+  }
+  resolveImportPath(filepath) {
+    if (/^\./.test(filepath)) {
+      return this.api.resolve(filepath);
+    }
+    return filepath;
+  }
+  /**
+   * Get absolute path to main
+   */
+  getMainPath() {
+    return path.join(this.getProjectPath(), this.getConfig('paths.main'));
+  }
+  /**
+   * Get absolute path to project
+   */
+  getProjectPath() {
+    return this.api.service.context;
+  }
+
+  /**
+   * Get config data or variable from uvue.config.js
+   */
+  getConfig(selector) {
+    let config = require('./uvue/uvueConfig')();
+
+    // Load config in project if exists
+    const configPath = path.join(this.getProjectPath(), 'uvue.config.js');
+    if (fs.existsSync(configPath)) {
+      const module = require(configPath);
+      config = merge(config, module.default || module);
+      // For HMR
+      delete require.cache[configPath];
+    }
+
+    // Imports
+    const imports = [];
+    for (let item of config.imports) {
+      // Convert import string to object with options
+      if (typeof item === 'string') {
+        item = {
+          src: item,
+          ssr: true,
+        };
+      }
+
+      // Get plugin absolute path
+      item.src = this.resolveImportPath(item.src);
+
+      imports.push(item);
+    }
+    config.imports = imports;
+
+    if (selector) return get(config, selector);
+    return config;
+  }
+
+  /**
+   * Get config data or variable from server.config.js
+   */
+  getServerConfig(selector) {
+    let config = require('./uvue/serverConfig')();
+
+    // Load config in project if exists
+    const configPath = this.api.resolve('server.config.js');
+    if (fs.existsSync(configPath)) {
+      const module = require(configPath);
+      config = merge(config, module.default || module);
+      // For HMR
+      delete require.cache[configPath];
+    }
+
+    // Plugins
+    const plugins = [];
+    for (let item of config.plugins) {
+      // Convert plugin string to object with options
+      if (typeof item === 'string') {
+        item = [item];
+      }
+
+      // Get plugin absolute path
+      item[0] = this.resolveImportPath(item[0]);
+
+      plugins.push(item);
+    }
+    config.plugins = plugins;
+
+    if (selector) return get(config, selector);
+    return config;
+  }
+
+  /**
+   * Install server plugins
+   */
+  installServerPlugins(server) {
+    const plugins = this.getServerConfig('plugins') || [];
+    for (const plugin of plugins) {
+      const [src, options] = plugin;
+
+      const m = require(src);
+      server.addPlugin(m.default || m, options);
+    }
+  }
+};
+

--- a/packages/@uvue/vue-cli-plugin-ssr/commands/build.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/commands/build.js
@@ -3,6 +3,8 @@ const webpack = require('webpack');
 const consola = require('consola');
 const formatStats = require('@vue/cli-service/lib/commands/build/formatStats');
 const execa = require('execa');
+const ApiUtil = require('../ApiUtil');
+
 
 const modifyConfig = (config, fn) => {
   if (Array.isArray(config)) {
@@ -63,7 +65,7 @@ module.exports = (api, options) => {
 
 function build(api, options, args) {
   return new Promise(async (resolve, reject) => {
-    const uvueDir = api.uvue.getServerConfig('uvueDir');
+    const uvueDir = new ApiUtil(api).getServerConfig('uvueDir');
 
     const isLegacyBuild = !process.env.VUE_CLI_MODERN_BUILD && process.env.VUE_CLI_MODERN_MODE;
     const isModernBuild = process.env.VUE_CLI_MODERN_MODE && process.env.VUE_CLI_MODERN_BUILD;

--- a/packages/@uvue/vue-cli-plugin-ssr/commands/fix-vuex.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/commands/fix-vuex.js
@@ -13,15 +13,15 @@ module.exports = api => {
       usage: 'vue-cli-service ssr:fix-vuex',
     },
     async function() {
-      const cf = new CodeFixer(path.join(api.uvue.getProjectPath(), 'src'));
+      const cf = new CodeFixer(path.join(new ApiUtil(api).getProjectPath(), 'src'));
 
       consola.info('Trying to find Vuex states files...');
       const files = await cf.findVuexStateFiles();
 
       for (const file in files) {
-        let cleanPath = file.replace(api.uvue.getProjectPath() + '/', '');
+        let cleanPath = file.replace(new ApiUtil(api).getProjectPath() + '/', '');
         if (os.platform() === 'win32') {
-          cleanPath = file.replace(api.uvue.getProjectPath().replace(/\//g, '\\') + '\\', '');
+          cleanPath = file.replace(new ApiUtil(api).getProjectPath().replace(/\//g, '\\') + '\\', '');
         }
 
         if (file.type === 'complex') {

--- a/packages/@uvue/vue-cli-plugin-ssr/commands/fix.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/commands/fix.js
@@ -1,5 +1,7 @@
 const path = require('path');
 const CodeFixer = require('../uvue/CodeFixer');
+const ApiUtil = require('../ApiUtil');
+
 
 module.exports = api => {
   api.registerCommand(
@@ -9,8 +11,8 @@ module.exports = api => {
       usage: 'vue-cli-service ssr:fix',
     },
     async function() {
-      const cf = new CodeFixer(path.join(api.uvue.getProjectPath(), 'src'));
-      await cf.run(api, api.uvue.getMainPath());
+      const cf = new CodeFixer(path.join(new ApiUtil(api).getProjectPath(), 'src'));
+      await cf.run(api, new ApiUtil(api).getMainPath());
     },
   );
 };

--- a/packages/@uvue/vue-cli-plugin-ssr/commands/serve.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/commands/serve.js
@@ -1,6 +1,7 @@
 const nodemon = require('nodemon');
 const consola = require('consola');
 const fs = require('fs-extra');
+const ApiUtil = require('../ApiUtil');
 
 const defaults = {
   host: 'localhost',
@@ -20,7 +21,7 @@ module.exports = (api, options) => {
       },
     },
     async function() {
-      const { watch, watchIgnore } = api.uvue.getServerConfig();
+      const { watch, watchIgnore } = new ApiUtil(api).getServerConfig();
       const vueCliPath = require.resolve('@vue/cli-service/bin/vue-cli-service.js');
 
       // Remove dist dir

--- a/packages/@uvue/vue-cli-plugin-ssr/commands/serveRun.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/commands/serveRun.js
@@ -1,4 +1,5 @@
 const { IpcMessenger } = require('@vue/cli-shared-utils');
+const ApiUtil = require('../ApiUtil');
 
 const defaults = {
   host: 'localhost',
@@ -57,7 +58,7 @@ async function startServer({ api, host, port, args }) {
     spaPaths,
     renderer,
     logger,
-  } = api.uvue.getServerConfig();
+  } = new ApiUtil(api).getServerConfig();
 
   const serverConfig = getWebpackConfig(api, { serve: true, client: false, host, port });
   const clientConfig = getWebpackConfig(api, { serve: true, client: true, host, port });
@@ -102,7 +103,7 @@ async function startServer({ api, host, port, args }) {
   });
 
   // Install plugins
-  api.uvue.installServerPlugins(server);
+  new ApiUtil(api).installServerPlugins(server);
 
   // Start server
   await server.start();

--- a/packages/@uvue/vue-cli-plugin-ssr/commands/start.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/commands/start.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const consola = require('consola');
 const { join } = require('path');
+const ApiUtil = require('../ApiUtil');
 
 const defaults = {
   host: '0.0.0.0',
@@ -23,7 +24,7 @@ module.exports = (api, options) => {
       },
     },
     async function(args) {
-      const serverConfig = api.uvue.getServerConfig();
+      const serverConfig = new ApiUtil(api).getServerConfig();
       const { uvueDir } = serverConfig;
 
       /**
@@ -78,7 +79,7 @@ module.exports = (api, options) => {
       });
 
       // Install plugins
-      api.uvue.installServerPlugins(server);
+      new ApiUtil(api).installServerPlugins(server);
 
       /**
        * Start server

--- a/packages/@uvue/vue-cli-plugin-ssr/uvue/StaticGenerate.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/uvue/StaticGenerate.js
@@ -5,6 +5,8 @@ const httpMocks = require('node-mocks-http');
 const { dirname } = require('path');
 const { merge } = require('lodash');
 const { Server } = require('@uvue/server');
+const ApiUtil = require('../ApiUtil');
+
 
 const whiteBox = str => chalk.bgWhite(chalk.black(` ${str} `));
 const greenBox = str => chalk.bgGreen(chalk.black(` ${str} `));
@@ -17,7 +19,7 @@ module.exports = class StaticGenerate {
     this.api = api;
     this.options = options;
 
-    const { uvueDir, spaPaths, renderer, static: staticConfig } = api.uvue.getServerConfig();
+    const { uvueDir, spaPaths, renderer, static: staticConfig } = new ApiUtil(api).getServerConfig();
 
     // Fake server to resolve renderer
     this.server = new Server({
@@ -27,7 +29,7 @@ module.exports = class StaticGenerate {
     });
 
     // Install plugins
-    api.uvue.installServerPlugins(this.server);
+    new ApiUtil(api).installServerPlugins(this.server);
 
     // Renderer
     this.renderer = this.server.createRenderer(this.server.getBuiltFiles());
@@ -72,7 +74,7 @@ module.exports = class StaticGenerate {
     }
 
     // Remove uvue dir
-    await fs.remove(`${this.options.outputDir}/${this.api.uvue.getServerConfig('uvueDir')}`);
+    await fs.remove(`${this.options.outputDir}/${new ApiUtil(this.api).getServerConfig('uvueDir')}`);
   }
 
   /**

--- a/packages/@uvue/vue-cli-plugin-ssr/uvue/index.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/uvue/index.js
@@ -3,12 +3,11 @@
 require = require('esm')(module);
 
 // Imports
-const path = require('path');
-const fs = require('fs-extra');
-const { merge, get } = require('lodash');
 const webpack = require('webpack');
 const defineOptions = require('../webpack/defineOptions');
 const UVuePlugin = require('../webpack/uvue/plugin');
+const ApiUtil = require('../ApiUtil');
+
 
 /**
  * UVue API for Vue CLI
@@ -19,8 +18,6 @@ module.exports = class {
    * @param {*} api Keep a reference of Vue CLI API
    */
   constructor(api) {
-    this.api = api;
-
     // Basic webpack conf for UVue (SPA mode)
     api.chainWebpack(chainConfig => {
       // Change main entry
@@ -36,7 +33,7 @@ module.exports = class {
       chainConfig.plugin('uvue-plugin').use(UVuePlugin, [{ api }]);
       chainConfig.module
         .rule('uvue-tranform')
-        .test([/(@|\.)uvue/, this.getMainPath()])
+        .test([/(@|\.)uvue/, new ApiUtil(api).getMainPath()])
         .use('uvue-loader')
         .loader('@uvue/vue-cli-plugin-ssr/webpack/uvue/loader.js')
         .options({
@@ -51,110 +48,5 @@ module.exports = class {
       // PWA: register service worker module
       /register-service-worker/,
     );
-  }
-
-  /**
-   * Get absolute path to project
-   */
-  getProjectPath() {
-    return this.api.service.context;
-  }
-
-  /**
-   * Get absolute path to main
-   */
-  getMainPath() {
-    return path.join(this.getProjectPath(), this.getConfig('paths.main'));
-  }
-
-  /**
-   * Get config data or variable from uvue.config.js
-   */
-  getConfig(selector) {
-    let config = require('./uvueConfig')();
-
-    // Load config in project if exists
-    const configPath = this.api.resolve('uvue.config.js');
-    if (fs.existsSync(configPath)) {
-      const module = require(configPath);
-      config = merge(config, module.default || module);
-      // For HMR
-      delete require.cache[configPath];
-    }
-
-    // Imports
-    const imports = [];
-    for (let item of config.imports) {
-      // Convert import string to object with options
-      if (typeof item === 'string') {
-        item = {
-          src: item,
-          ssr: true,
-        };
-      }
-
-      // Get plugin absolute path
-      item.src = this.resolveImportPath(item.src);
-
-      imports.push(item);
-    }
-    config.imports = imports;
-
-    if (selector) return get(config, selector);
-    return config;
-  }
-
-  /**
-   * Get config data or variable from server.config.js
-   */
-  getServerConfig(selector) {
-    let config = require('./serverConfig')();
-
-    // Load config in project if exists
-    const configPath = this.api.resolve('server.config.js');
-    if (fs.existsSync(configPath)) {
-      const module = require(configPath);
-      config = merge(config, module.default || module);
-      // For HMR
-      delete require.cache[configPath];
-    }
-
-    // Plugins
-    const plugins = [];
-    for (let item of config.plugins) {
-      // Convert plugin string to object with options
-      if (typeof item === 'string') {
-        item = [item];
-      }
-
-      // Get plugin absolute path
-      item[0] = this.resolveImportPath(item[0]);
-
-      plugins.push(item);
-    }
-    config.plugins = plugins;
-
-    if (selector) return get(config, selector);
-    return config;
-  }
-
-  /**
-   * Install server plugins
-   */
-  installServerPlugins(server) {
-    const plugins = this.getServerConfig('plugins') || [];
-    for (const plugin of plugins) {
-      const [src, options] = plugin;
-
-      const m = require(src);
-      server.addPlugin(m.default || m, options);
-    }
-  }
-
-  resolveImportPath(filepath) {
-    if (/^\./.test(filepath)) {
-      return this.api.resolve(filepath);
-    }
-    return filepath;
   }
 };

--- a/packages/@uvue/vue-cli-plugin-ssr/webpack/client.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/webpack/client.js
@@ -1,9 +1,11 @@
 // const VueSSRClientPlugin = require('vue-server-renderer/client-plugin');
 const VueSSRClientPlugin = require('./plugins/VueSSRClientPlugin');
 const ModernModePlugin = require('./plugins/ModernModePlugin');
+const ApiUtil = require('../ApiUtil');
+
 
 module.exports = (api, chainConfig) => {
-  const uvueDir = api.uvue.getServerConfig('uvueDir');
+  const uvueDir = new ApiUtil(api).getServerConfig('uvueDir');
 
   // Change main entry
   chainConfig.entryPoints

--- a/packages/@uvue/vue-cli-plugin-ssr/webpack/css.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/webpack/css.js
@@ -1,10 +1,11 @@
 const SSRMiniCssExtractPlugin = require('./plugins/SSRMiniCssExtractPlugin');
+const ApiUtil = require('../ApiUtil');
 
 module.exports = (api, chainConfig, isClient) => {
   // CSS rules names
   const preProcessors = ['css', 'postcss', 'scss', 'sass', 'less', 'stylus'];
 
-  const cssConfig = api.uvue.getConfig('css');
+  const cssConfig = new ApiUtil(api).getConfig('css');
   const normalTypes = ['normal', 'normal-modules'];
   const vueTypes = ['vue', 'vue-module'];
 

--- a/packages/@uvue/vue-cli-plugin-ssr/webpack/server.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/webpack/server.js
@@ -1,8 +1,10 @@
 const VueSSRServerPlugin = require('vue-server-renderer/server-plugin');
 const nodeExternals = require('webpack-node-externals');
+const ApiUtil = require('../ApiUtil');
+
 
 module.exports = (api, chainConfig) => {
-  const { uvueDir, externalsWhitelist } = api.uvue.getServerConfig();
+  const { uvueDir, externalsWhitelist } = new ApiUtil(api).getServerConfig();
 
   // Change entry point
   chainConfig.entryPoints

--- a/packages/@uvue/vue-cli-plugin-ssr/webpack/ssr.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/webpack/ssr.js
@@ -3,6 +3,8 @@ const WebpackBar = require('webpackbar');
 const cssConfig = require('./css');
 const defineOptions = require('./defineOptions');
 const merge = require('lodash/merge');
+const ApiUtil = require('../ApiUtil');
+
 
 module.exports = (api, options = {}) => {
   const opts = Object.assign({ client: true, ssr: true }, options);
@@ -11,11 +13,11 @@ module.exports = (api, options = {}) => {
   // Get base config from SPA
   const chainConfig = api.resolveChainableWebpackConfig();
 
-  const uvueDir = api.uvue.getServerConfig('uvueDir');
+  const uvueDir = new ApiUtil(api).getServerConfig('uvueDir');
 
   // Change template for HTMLWebpackPlugin
   let htmlOptions = {
-    template: api.resolve(api.uvue.getConfig('paths.template')),
+    template: api.resolve(new ApiUtil(api).getConfig('paths.template')),
     filename: `${uvueDir}/ssr.html`,
   };
 
@@ -73,7 +75,7 @@ module.exports = (api, options = {}) => {
     const messages = [];
 
     if (host && port) {
-      const httpsConfig = api.uvue.getServerConfig('https');
+      const httpsConfig = new ApiUtil(api).getServerConfig('https');
       messages.push(
         `Server is running: ${
           httpsConfig.key && httpsConfig.cert ? 'https' : 'http'

--- a/packages/@uvue/vue-cli-plugin-ssr/webpack/uvue/loader.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/webpack/uvue/loader.js
@@ -2,6 +2,8 @@ const path = require('path');
 const os = require('os');
 const mm = require('micromatch');
 const { RQuery } = require('@uvue/rquery');
+const ApiUtil = require('../../ApiUtil');
+
 
 /**
  * Simple loader to find and replace code before final compilation
@@ -11,11 +13,11 @@ module.exports = async function(content, map, meta) {
 
   // Get UVue API
   const { uvue } = this.query.api;
-  const mainPath = uvue.getMainPath();
+  const mainPath = new ApiUtil(this.query.api).getMainPath();
 
   if (mm.isMatch(this.resourcePath, '**/@uvue/core/(client|server).js')) {
     // Get absolute path to generated main.js
-    const dirPath = path.join(uvue.getProjectPath(), 'node_modules', '.uvue');
+    const dirPath = path.join(new ApiUtil(this.query.api).getProjectPath(), 'node_modules', '.uvue');
     let mainPath = path.join(dirPath, 'main.js');
     if (os.platform() === 'win32') {
       mainPath = mainPath.replace(/\\/g, '/');

--- a/packages/@uvue/vue-cli-plugin-ssr/webpack/uvue/plugin.js
+++ b/packages/@uvue/vue-cli-plugin-ssr/webpack/uvue/plugin.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const os = require('os');
+const ApiUtil = require('../../ApiUtil');
 
 /**
  * Simple webpack plugin to generate main.js with imports
@@ -33,7 +34,7 @@ module.exports = class UVuePlugin {
     });
 
     const callPluginsHooks = async (type, compilation) => {
-      const plugins = this.uvue.getServerConfig('plugins');
+      const plugins = new ApiUtil(this.api).getServerConfig('plugins');
       for (const plugin of plugins) {
         const [src, options] = plugin;
         let m = require(src);
@@ -60,10 +61,10 @@ module.exports = class UVuePlugin {
    */
   async writeMain() {
     // Get absolute path for generated main.js
-    const dirPath = path.join(this.uvue.getProjectPath(), 'node_modules', '.uvue');
+    const dirPath = path.join(new ApiUtil(this.api).getProjectPath(), 'node_modules', '.uvue');
     const mainPath = path.join(dirPath, 'main.js');
 
-    let importMainPath = this.uvue.getMainPath();
+    let importMainPath = new ApiUtil(this.api).getMainPath();
     if (os.platform() === 'win32') {
       importMainPath = importMainPath.replace(/\\/g, '/');
     }
@@ -91,7 +92,7 @@ module.exports = class UVuePlugin {
     let result = '';
 
     // Handle imports defined in uvue config
-    const { normal, noSSR } = this.uvue.getConfig('imports').reduce(
+    const { normal, noSSR } = new ApiUtil(this.api).getConfig('imports').reduce(
       (result, item) => {
         if (item.ssr === false) result.noSSR.push(item.src);
         else result.normal.push(item.src);
@@ -109,12 +110,12 @@ module.exports = class UVuePlugin {
   buildPlugins() {
     let result = '';
 
-    let configPath = path.join(this.uvue.getProjectPath(), 'uvue.config');
+    let configPath = path.join(new ApiUtil(this.api).getProjectPath(), 'uvue.config');
     if (os.platform() === 'win32') {
       configPath = configPath.replace(/\\/g, '/');
     }
 
-    if (this.uvue.getConfig('plugins')) {
+    if (new ApiUtil(this.api).getConfig('plugins')) {
       result = `
 import UVue from '@uvue/core';
 import uvueConfig from '${configPath}';
@@ -127,7 +128,7 @@ for (const index in plugins) {
 }
       `;
 
-      const plugins = this.uvue.getConfig('plugins');
+      const plugins = new ApiUtil(this.api).getConfig('plugins');
       for (const index in plugins) {
         let plugin = plugins[index];
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactor to avoid circular dependence. More detail #37 

**What is the current behavior?**
Create circular dependencie in UvueLoader

**What is the new behavior?**
Use a ApiUtil.js to avoid to have a reference to the api from uvue loader. 

**Checklist**:
- [ ] Tests
- [ ] Documentation

// I don't know how to create a test for this, is a first time that I modify a webpack plugin, but basically it can be tested with `JSON.stringify(api);` 

