### PR TITLE
fix: change body insert to a non-capturing group

### DIFF
--- a/packages/@uvue/server/src/Renderer.ts
+++ b/packages/@uvue/server/src/Renderer.ts
@@ -85,7 +85,7 @@ export class Renderer implements IRenderer {
       .replace(/data-html-attrs(="")?/i, htmlAttrs)
       .replace(/data-body-attrs(="")?/i, bodyAttrs)
       .replace(/<ssr-head\s*\/?>/i, head)
-      .replace(/(<div id="?app"?><\/div>|<ssr-body\s*\/?>)/i, body)
+      .replace(/(?:<div id="?app"?><\/div>|<ssr-body\s*\/?>)/i, body)
       .replace(/<\/ssr-head>/i, '')
       .replace(/<\/ssr-body>/i, '');
 


### PR DESCRIPTION
When the body contains the string `$1` it was being treated as a token reference, which results in all `$1` strings being replaced with `<ssr-body />`. By changing the capture group to a non-capture group, the problem is solved.

**What kind of change does this PR introduce?**

Fixes a bug where `$1` is replaced with `<ssr-body />` in the SSR page.

**What is the current behavior?**

If the string `$1` appears anywhere in the SSR rendered HTML, it is replaced with `<ssr-body />`.

**What is the new behavior?**

Occurrences of the string `$1` are now left alone.

**Checklist**:
- [ ] Documentation
- [ ] Tests

**NOTES:**

It was difficult for me to track how the unit test mocks work, so I didn't update the tests to include the `$1` string.
