### PR TITLE
(server) Fix syntax error in DATA

### DIFF
--- a/packages/@uvue/server/src/utils.ts
+++ b/packages/@uvue/server/src/utils.ts
@@ -1,7 +1,8 @@
 import fastSafeStringify from 'fast-safe-stringify';
 
-const UNSAFE_CHARS_REGEXP = /[<>\/\u2028\u2029]/g;
+const UNSAFE_CHARS_REGEXP = /[$<>\/\u2028\u2029]/g;
 const ESCAPED_CHARS = {
+  '$': '\\u0024',
   '/': '\\u002F',
   '<': '\\u003C',
   '>': '\\u003E',


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix syntax error in DATA

**What is the current behavior?**
When a string in the state contains `$&`, it will be replaced with `<div id="app"></div>` in the `__DATA__`. String like ``$` `` and `$'` will become empty.

**What is the new behavior?**
Escape all `$` characters appear in state with jsonEncode
