### PR TITLE
(client) Redirect whole page if passed a complete URL

### DIFF
--- a/packages/@uvue/core/lib/redirect.js
+++ b/packages/@uvue/core/lib/redirect.js
@@ -36,7 +36,11 @@ export const doRedirect = ({ app, res, ssr, router, isClient }, { location, stat
 
   if (isClient) {
     // Client side
-    router.replace(location);
+    try {
+      window.location = new URL(location);
+    } catch {
+      router.replace(location);
+    }
   } else {
     // Server side
     ssr.redirected = {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It fixes redirection by URL on the client-side.

**What is the current behavior?**

`this.$redirect('http://example.com');` works fine in SSR, but if it is called on the client-side then the URL passed to VueRouter that will try to resolve it in registered routes.

**What is the new behavior?**

If `$redirect` argument is a complete URL (has protocol and host, `URL` won't fail parsing it) then the browser window would be completely redirected to that URL otherwise it would try to resolve it using VueRouter as before.

**Checklist**:
- [ ] Documentation
- [ ] Tests

I think the proposed behavior is already intended by current documentation.

It is tricky to test because it is needed an external service or a separately hosted page. Can we redirect to `example.com` or so?