### PR TITLE
add watchOptions for server compiler

### DIFF
--- a/packages/@uvue/server/src/devMiddleware.ts
+++ b/packages/@uvue/server/src/devMiddleware.ts
@@ -121,8 +121,10 @@ export const setupDevMiddleware = async (
     }
   };
 
+  const serverCompilerWatchOptions = app.options.devServer.middleware.watchOptions || {};
+
   compiler.hooks.done.tap('WebapackClientDev', handleCompilation);
-  compiler.compilers[1].watch({}, (err, stats) => {
+  compiler.compilers[1].watch(serverCompilerWatchOptions, (err, stats) => {
     if (err) {
       throw err;
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Adds watchOptions for server compiler.

**What is the current behavior?**
When we specify `devServer.middleware.watchOptions` in server.config.js file, this parameter only applies to client compiler.

**What is the new behavior?**
When we specify `devServer.middleware.watchOptions` in server.config.js file, this parameter also applies to server compiler.

**Checklist**:
- [x] Documentation
- [x] Tests
